### PR TITLE
Update jetpack-download.sh with new command line options for SDK Manager 0.9.14.4961

### DIFF
--- a/docker/jetpack/download-jetpack.sh
+++ b/docker/jetpack/download-jetpack.sh
@@ -55,6 +55,6 @@ fi
 echo "mkdir -p /tmp/${JETPACK_VERSION}/${DEVICE_ID}"
 mkdir -p /tmp/${JETPACK_VERSION}/${DEVICE_ID}
 
-echo "${XVFB} sdkmanager --cli downloadonly --user ${NV_USER} --logintype ${NV_LOGIN_TYPE} --product ${PRODUCT} --version ${JETPACK_VERSION} --targetos ${TARGET_OS} ${DEVICE_OPTION} ${DEVICE_ID} --flash skip --license ${ACCEPT_SDK_LICENCE} --downloadfolder /tmp/${JETPACK_VERSION}/${DEVICE_ID}"
-${XVFB} sdkmanager --cli downloadonly --user ${NV_USER} --logintype ${NV_LOGIN_TYPE} --product ${PRODUCT} --version ${JETPACK_VERSION} --targetos ${TARGET_OS} ${DEVICE_OPTION} ${DEVICE_ID} --flash skip --license ${ACCEPT_SDK_LICENCE} --downloadfolder /tmp/${JETPACK_VERSION}/${DEVICE_ID}
+echo "${XVFB} sdkmanager --cli downloadonly --user ${NV_USER} --logintype ${NV_LOGIN_TYPE} --product ${PRODUCT} --version ${JETPACK_VERSION} --targetos ${TARGET_OS} ${DEVICE_OPTION} ${DEVICE_ID} --flash --installontarget --license ${ACCEPT_SDK_LICENCE} --downloadfolder /tmp/${JETPACK_VERSION}/${DEVICE_ID}"
+${XVFB} sdkmanager --cli downloadonly --user ${NV_USER} --logintype ${NV_LOGIN_TYPE} --product ${PRODUCT} --version ${JETPACK_VERSION} --targetos ${TARGET_OS} ${DEVICE_OPTION} ${DEVICE_ID} --flash --installontarget --license ${ACCEPT_SDK_LICENCE} --downloadfolder /tmp/${JETPACK_VERSION}/${DEVICE_ID}
 


### PR DESCRIPTION
SDK Manager CLI changes require removal of the skip param to `--flash` and addition of the undocumented `--installontarget` parameter in order to download the packages which were included in previous versions.