### PR TITLE
Removing overlay support for 4.3.

### DIFF
--- a/flash/l4t/32.3.1/default.Dockerfile
+++ b/flash/l4t/32.3.1/default.Dockerfile
@@ -62,8 +62,6 @@ RUN echo "${ROOT_FS_MD5} *./${ROOT_FS}" | md5sum -c - && \
     rm /${ROOT_FS}
 
 WORKDIR /Linux_for_Tegra
-RUN ./apply_binaries.sh --target-overlay
-
 
 ARG TARGET_BOARD
 ARG ROOT_DEVICE
@@ -71,6 +69,7 @@ ENV TARGET_BOARD=$TARGET_BOARD
 ENV ROOT_DEVICE=$ROOT_DEVICE
 
 RUN echo "#!/bin/bash" >> entrypoint.sh && \
+    echo "sudo ./apply_binaries.sh" >> entrypoint.sh && \
     echo "echo \"sudo ./flash.sh \$* ${TARGET_BOARD} ${ROOT_DEVICE}\"" >> entrypoint.sh && \
     echo "sudo ./flash.sh \$* ${TARGET_BOARD} ${ROOT_DEVICE}" >> entrypoint.sh && \
     chmod +x entrypoint.sh

--- a/generation/ubuntu1804/flash/l4t/default.Dockerfile.jinja
+++ b/generation/ubuntu1804/flash/l4t/default.Dockerfile.jinja
@@ -61,28 +61,11 @@ RUN echo "${ROOT_FS_MD5} *./${ROOT_FS}" | md5sum -c - && \
     tar -xp --overwrite -f /${ROOT_FS} && \
     rm /${ROOT_FS}
 
-{%- if ctx.drivers.version == "32.3.1" and ctx.target_overlay == False %}
-# pre-req for Linux_for_Tegra/nv_tegra/nv-apply-debs.sh as it tries to chroot
-COPY --from=qemu /usr/bin/qemu-aarch64-static /Linux_for_Tegra/nv_tegra/qemu-aarch64-static
-RUN sed -i '/.*LC_ALL=C chroot . mount -t proc none \/proc.*/c\#LC_ALL=C chroot . mount -t proc none \/proc' ./Linux_for_Tegra/nv_tegra/nv-apply-debs.sh
-RUN sed -i '/.*umount ${L4T_ROOTFS_DIR}\/proc.*/c\#umount ${L4T_ROOTFS_DIR}\/proc' ./Linux_for_Tegra/nv_tegra/nv-apply-debs.sh
-RUN sed -i '/.*	LC_ALL=C chroot . dpkg -i --path-include=\"\/usr\/share\/doc\/\*\" \"${pre_deb_list\[\@\]}\".*/c\	apt install -y --no-install-recommends \"${pre_deb_list[@]}\"' ./Linux_for_Tegra/nv_tegra/nv-apply-debs.sh
-RUN sed -i '/.*LC_ALL=C chroot . dpkg -i --path-include=\"\/usr\/share\/doc\/\*\" \"${deb_list\[\@\]}\".*/c\apt install -y --no-install-recommends \"${deb_list[@]}\"' ./Linux_for_Tegra/nv_tegra/nv-apply-debs.sh
-{%- endif %}
-
 WORKDIR /Linux_for_Tegra
 
-{%- if ctx.drivers.version == "32.3.1" and ctx.target_overlay == True %}
-RUN ./apply_binaries.sh --target-overlay
-{% else %}
+{%- if ctx.drivers.version != "32.3.1" %}
 RUN ./apply_binaries.sh
 {% endif %}
-
-{%- if ctx.drivers.version == "32.3.1" and ctx.target_overlay == False %}
-# In 32.3.1, this will use deb packages instead of the archive overlay
-# Patch OTA apt source
-RUN sed -i "s/<SOC>/t{{ ctx.SOC }}/g" "/Linux_for_Tegra/rootfs/etc/apt/sources.list.d/nvidia-l4t-apt-source.list"
-{%- endif %}
 
 ARG TARGET_BOARD
 ARG ROOT_DEVICE
@@ -90,6 +73,9 @@ ENV TARGET_BOARD=$TARGET_BOARD
 ENV ROOT_DEVICE=$ROOT_DEVICE
 
 RUN echo "#!/bin/bash" >> entrypoint.sh && \
+{%- if ctx.drivers.version == "32.3.1" %}
+    echo "sudo ./apply_binaries.sh" >> entrypoint.sh && \
+{%- endif %}
     echo "echo \"sudo ./flash.sh \$* ${TARGET_BOARD} ${ROOT_DEVICE}\"" >> entrypoint.sh && \
     echo "sudo ./flash.sh \$* ${TARGET_BOARD} ${ROOT_DEVICE}" >> entrypoint.sh && \
     chmod +x entrypoint.sh


### PR DESCRIPTION
 Applying the binaries has to be done on image run due to chrooting. This partially fixes #39 - the other half of the fix must be done on rootfs creation.